### PR TITLE
Add Header Content-Type

### DIFF
--- a/LogCollector/src/com/qihoo/linker/logcollector/upload/HttpManager.java
+++ b/LogCollector/src/com/qihoo/linker/logcollector/upload/HttpManager.java
@@ -110,6 +110,7 @@ public class HttpManager {
 			
 			ByteArrayEntity formEntity = new ByteArrayEntity(bos.toByteArray());
 			post.setEntity(formEntity);
+			post.setHeader("Content-Type", "multipart/form-data; boundary=" + BOUNDARY);
 			HttpResponse response = client.execute(post);
 			StatusLine status = response.getStatusLine();
 			int statusCode = status.getStatusCode();


### PR DESCRIPTION
If there is not Header Content-Type in upload request, then the request can't be accepted by upload handler using commons-httpclient.
